### PR TITLE
Add _redirects to not break URLs with the site move

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,8 @@ markdown: kramdown
 theme: minima
 plugins:
   - jekyll-feed
+include:
+  - _redirects
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/source/_redirects
+++ b/source/_redirects
@@ -1,0 +1,9 @@
+# https://www.netlify.com/docs/redirects/
+
+# Compatibility links for the old website, now community.
+# All are 302s because that's way less problematic if there's an error or change!
+
+/events/* http://community.uk.python.org/events/:splat 302
+/groups/* http://community.uk.python.org/groups/:splat 302
+/news/* http://community.uk.python.org/news/:splat 302
+/john-pinner-award/ http://community.uk.python.org/john-pinner-award/ 302


### PR DESCRIPTION
Old uk.python is moving to community.uk, and this site is becoming uk.

Community site retains the dynamic fun stuff like news and events etc.
while this site is simpler and more static