### PR TITLE
Temporarily remove links and redirects to community site

### DIFF
--- a/source/_redirects
+++ b/source/_redirects
@@ -1,9 +1,0 @@
-# https://www.netlify.com/docs/redirects/
-
-# Compatibility links for the old website, now community.
-# All are 302s because that's way less problematic if there's an error or change!
-
-/events/* http://community.uk.python.org/events/:splat 302
-/groups/* http://community.uk.python.org/groups/:splat 302
-/news/* http://community.uk.python.org/news/:splat 302
-/john-pinner-award/ http://community.uk.python.org/john-pinner-award/ 302

--- a/source/index.md
+++ b/source/index.md
@@ -14,4 +14,3 @@ It is the organisation behind [PyCon UK](http://pyconuk.org).
 * [More about the UKPA](/about/)
 * [PyCon UK](http://pyconuk.org)
 * [Get involved](mailto:trustees@uk.python.org)
-* [Regional user groups and events](http://community.uk.python.org/)


### PR DESCRIPTION
We've currently "lost control of" the community site because GitHub Pages doesn't verify domain ownership and someone's set community.uk.python.org for their own repo.

Disabling links/redirections there until GH Support can resolve this for us / we move the community site